### PR TITLE
Update deno packages

### DIFF
--- a/api-gateway-deno/Dockerfile
+++ b/api-gateway-deno/Dockerfile
@@ -1,6 +1,10 @@
-FROM hayd/alpine-deno
+FROM denoland/deno:alpine-1.16.2
 
+RUN mkdir /root/.deno
 RUN mkdir /app
 
 WORKDIR /app
 ADD . /app
+
+RUN deno install -A --unstable --import-map=https://deno.land/x/trex/import_map.json -n trex --no-check https://deno.land/x/trex/cli.ts
+RUN trex install

--- a/api-gateway-deno/README.md
+++ b/api-gateway-deno/README.md
@@ -6,19 +6,33 @@
 
 ## Setup
 
+We use [trex](https://crewdevio.mod.land/projects/Trex) to manage deno packages, so let's [install it](https://github.com/crewdevio/Trex#installation) first:
+
+```bash
+deno install -A --unstable --import-map=https://deno.land/x/trex/import_map.json -n trex --no-check https://deno.land/x/trex/cli.ts
+
+```
+
+Then clone this repo, go to `api-gateway-deno` folder to install dependencies and start service:
+
+
 ```bash
 git clone https://github.com/ndaidong/microservices.git
 cd  microservices/api-gateway-deno
 
-deno run --allow-net --allow-read app.ts
+# install dependencies
+trex install
 
-# run with docker
+# start
+trex run start
+
+# another way, try to run with docker
 docker-compose up
 ```
 
 ### Configurations
 
-Before starting, the proxy and endpoints should be defined in `service.json`, for example:
+Proxy and the endpoints should be defined in `service.json`, for example:
 
 
 ```json

--- a/api-gateway-deno/app.ts
+++ b/api-gateway-deno/app.ts
@@ -1,7 +1,7 @@
 // app
 
-import { opine } from 'https://deno.land/x/opine@1.9.1/mod.ts';
-import { proxy } from "https://deno.land/x/opineHttpProxy@2.9.1/mod.ts";
+import { opine } from 'opine';
+import { proxy } from 'opinehttpproxy';
 
 import logger from './utils/logger.ts';
 

--- a/api-gateway-deno/app.ts
+++ b/api-gateway-deno/app.ts
@@ -1,7 +1,7 @@
 // app
 
-import { opine } from 'https://deno.land/x/opine@0.21.2/mod.ts';
-import { proxy } from "https://deno.land/x/opineHttpProxy@2.1.0/mod.ts";
+import { opine } from 'https://deno.land/x/opine@1.9.1/mod.ts';
+import { proxy } from "https://deno.land/x/opineHttpProxy@2.9.1/mod.ts";
 
 import logger from './utils/logger.ts';
 

--- a/api-gateway-deno/docker-compose.yaml
+++ b/api-gateway-deno/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - micro-net
     restart: always
     command: >
-      deno run --allow-net --allow-read app.ts
+      trex run start
 
 networks:
   micro-net:

--- a/api-gateway-deno/import_map.json
+++ b/api-gateway-deno/import_map.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "opine": "https://deno.land/x/opine@1.9.1/mod.ts",
+    "opinehttpproxy": "https://deno.land/x/opineHttpProxy@2.9.1/mod.ts"
+  }
+}

--- a/api-gateway-deno/run.json
+++ b/api-gateway-deno/run.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "start": "deno run --allow-net --allow-read --import-map=import_map.json ./app.ts"
+  },
+  "files": ["./app.ts"]
+}


### PR DESCRIPTION
- Use `trex` to manage dependencies
- Change deno docker image to denoland